### PR TITLE
point to the right doc url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ https://github.com/sagemath/pplpy
 Documentation
 -------------
 
-An online version of the documentation is available at http://www.labri.fr/perso/vdelecro/pplpy/latest/
+An online version of the documentation is available at https://www.sagemath.org/pplpy/
 
 Compiling the html documentation requires make and `sphinx <http://www.sphinx-doc.org/en/master/>`_.
 Before building the documentation, you need to install the pplpy package (sphinx uses Python introspection).


### PR DESCRIPTION
The README has a link to the doc. We now point to https://www.sagemath.org/pplpy/